### PR TITLE
fix: Remove awslabs from README URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ This is *experimental* software, and support may be discontinued in the future. 
 the [Python SDK](https://github.com/aws/amazon-braket-sdk-python). We may change, remove, or deprecate parts of the API when making new releases.
 Please review the [CHANGELOG](CHANGELOG.md) for information about changes in each release. 
 
-[![Stable docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://awslabs.github.io/Braket.jl/stable)
-[![Latest docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://awslabs.github.io/Braket.jl/dev)
-[![CI](https://github.com/awslabs/braket.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/awslabs/braket.jl/actions/workflows/CI.yml)
-[![codecov](https://codecov.io/gh/awslabs/braket.jl/branch/main/graph/badge.svg?token=QC9P7HQY4V)](https://codecov.io/gh/awslabs/braket.jl)
+[![Stable docs](https://img.shields.io/badge/docs-stable-blue.svg)](https://amazon-braket.github.io/Braket.jl/stable)
+[![Latest docs](https://img.shields.io/badge/docs-dev-blue.svg)](https://amazon-braket.github.io/Braket.jl/dev)
+[![CI](https://github.com/amazon-braket/braket.jl/actions/workflows/CI.yml/badge.svg)](https://github.com/amazon-braket/braket.jl/actions/workflows/CI.yml)
+[![codecov](https://codecov.io/gh/amazon-braket/braket.jl/branch/main/graph/badge.svg?token=QC9P7HQY4V)](https://codecov.io/gh/amazon-braket/braket.jl)
 
 ## Installation & Prerequisites
 
@@ -84,9 +84,9 @@ What's currently implemented in *pure* Julia:
 
 **Features to add:**
 
-- [Support for pickled jobs results](https://github.com/awslabs/Braket.jl/issues/18)
+- [Support for pickled jobs results](https://github.com/amazon-braket/Braket.jl/issues/18)
 - More robust entry point verification for jobs
-- [Pulse control](https://github.com/awslabs/Braket.jl/issues/15)
+- [Pulse control](https://github.com/amazon-braket/Braket.jl/issues/15)
 
 ## Security
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Since this is all hosted at `amazon-braket` now and not `awslabs`, the URLs should reflect that

*Testing done:* N/A

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/awslabs/braket-jl/blob/main/README.md) and [API docs](https://github.com/awslabs/braket-jl/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have installed and run [`git secrets`](https://github.com/awslabs/git-secrets) to make sure I did not commit any sensitive information (passwords or credentials)
- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
